### PR TITLE
Add support for dealer site selection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@wayke-se/ecom",
-  "version": "3.3.0",
+  "version": "3.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wayke-se/ecom",
-  "version": "3.3.0",
+  "version": "3.4.1",
   "description": "A SDK to utilize Wayke e-commerce APIs",
   "main": "src/index.ts",
   "typings": "src/index.d.ts",

--- a/src/http/apis/orders.spec.ts
+++ b/src/http/apis/orders.spec.ts
@@ -8,7 +8,31 @@ const fixture = (name: string, withValues: any = undefined): any =>
 
 describe("API: Orders", () => {
     describe("init()", () => {
-        it("calls the correct URL", async () => {
+        it("calls the correct URL without branch ID", async () => {
+            const fake = fixture("IConfiguration");
+            const config = Configuration.bind(fake);
+
+            const http = require("..");
+            http.json = jest.fn(
+                () =>
+                    new Promise((resolve) => {
+                        const data = fixture("IOrderOptionsResponse");
+                        const response = fixture("IApiResponse", {
+                            response: data,
+                            successful: true,
+                        });
+                        resolve(response);
+                    })
+            );
+            const request = fixture("IOrderOptionsRequest");
+            request.branchId = undefined;
+            await init(request, config);
+
+            const expected = `${fake.api.address}/v2/orders/new?vehicleId=${request.id}`;
+            const args = http.json.mock.calls[0];
+            expect(args[0]).toEqual(expected);
+        });
+        it("calls the correct URL with branch ID", async () => {
             const fake = fixture("IConfiguration");
             const config = Configuration.bind(fake);
 
@@ -27,7 +51,7 @@ describe("API: Orders", () => {
             const request = fixture("IOrderOptionsRequest");
             await init(request, config);
 
-            const expected = `${fake.api.address}/v2/orders/new?vehicleId=${request.id}`;
+            const expected = `${fake.api.address}/v2/orders/new?vehicleId=${request.id}&branchId=${request.branchId}`;
             const args = http.json.mock.calls[0];
             expect(args[0]).toEqual(expected);
         });

--- a/src/http/apis/orders.ts
+++ b/src/http/apis/orders.ts
@@ -69,6 +69,14 @@ const validateCreateResponse = (
     return response.response;
 };
 
+const getInitUrl = ({ id, branchId }: IOrderOptionsRequest): string => {
+    const url = `/v2/orders/new?vehicleId=${id}`;
+
+    if (!branchId) return url;
+
+    return `${url}&branchId=${branchId}`;
+};
+
 export const init = (
     request: IOrderOptionsRequest,
     config: IConfiguration
@@ -76,13 +84,13 @@ export const init = (
     http
         .captureStateContext(
             http.json<IOrderOptionsResponseData>(
-                `${config.getApiAddress()}/v2/orders/new?vehicleId=${
-                    request.id
-                }`,
+                `${config.getApiAddress()}${getInitUrl(request)}`,
                 buildOptionsRequest()
             )
         )
         .then(validateOptionsResponse);
+
+const getCreateUrl = () => "/v2/orders";
 
 export const create = (
     request: IOrderCreateRequest,
@@ -91,7 +99,7 @@ export const create = (
     http
         .captureStateContext(
             http.json<IOrderCreateResponseData>(
-                `${config.getApiAddress()}/v2/orders`,
+                `${config.getApiAddress()}${getCreateUrl()}`,
                 buildCreateRequest(request, config, http.context())
             )
         )

--- a/src/http/apis/payments.ts
+++ b/src/http/apis/payments.ts
@@ -10,6 +10,7 @@ const buildLookupRequest = (
     lookupRequest: IPaymentLookupRequest
 ): RequestInit => {
     const content = {
+        branchId: lookupRequest.branchId,
         duration: lookupRequest.duration,
         downPayment: lookupRequest.downPayment,
         residual: lookupRequest.residual,

--- a/src/orders/order-options-request-builder.spec.ts
+++ b/src/orders/order-options-request-builder.spec.ts
@@ -36,12 +36,22 @@ describe("OrderOptionsRequestBuilder", () => {
         });
     });
 
+    describe(":forDealer()", () => {
+        it("returns the OrderOptionsRequestBuilder instance", () => {
+            const builder = new OrderOptionsRequestBuilder();
+            const instance = builder.forDealer("dealer-id");
+
+            expect(instance).toBe(builder);
+        });
+    });
+
     describe(":build()", () => {
         it("returns a IOrderOptionsRequest for the specified builder properties", () => {
             const expected = fixture("IOrderOptionsRequest");
 
             const actual = new OrderOptionsRequestBuilder()
                 .forVehicle(expected.id)
+                .forDealer(expected.branchId)
                 .build();
 
             expect(actual).toEqual(expected);

--- a/src/orders/order-options-request-builder.ts
+++ b/src/orders/order-options-request-builder.ts
@@ -18,6 +18,12 @@ export class OrderOptionsRequestBuilder {
         return this;
     }
 
+    public forDealer(id: string): OrderOptionsRequestBuilder {
+        this.properties.branchId = id;
+
+        return this;
+    }
+
     public build(): IOrderOptionsRequest {
         return this.properties as IOrderOptionsRequest;
     }

--- a/src/orders/order-options-response.spec.ts
+++ b/src/orders/order-options-response.spec.ts
@@ -2,6 +2,7 @@ const fixtures = require("../../test/fixtures");
 
 import { PaymentLookupResponse } from "../payments/payment-lookup-response";
 import { OrderOptionsResponse } from "./order-options-response";
+import { IDealerOption } from "./types";
 
 const fixture = (name: string, withData: any = undefined): any =>
     fixtures.create(name, withData);
@@ -12,6 +13,40 @@ describe("OrderOptionsResponse", () => {
             expect(() => {
                 new OrderOptionsResponse(null as any);
             }).toThrowError();
+        });
+    });
+
+    describe(":requiresDealerSelection()", () => {
+        it("is falsy when only one dealer is available", () => {
+            const response = fixture("IOrderOptionsResponse");
+            response.dealers = [fixture("IDealerOption")];
+            const actual = new OrderOptionsResponse(
+                response
+            ).requiresDealerSelection();
+
+            expect(actual).toBeFalsy();
+        });
+        it("is truthy when more than one dealer is available", () => {
+            const response = fixture("IOrderOptionsResponse");
+            response.dealers = [
+                fixture("IDealerOption"),
+                fixture("IDealerOption"),
+            ];
+            const actual = new OrderOptionsResponse(
+                response
+            ).requiresDealerSelection();
+
+            expect(actual).toBeTruthy();
+        });
+    });
+
+    describe(":getDealerSites()", () => {
+        it("returns a list of available dealers", () => {
+            const response = fixture("IOrderOptionsResponse");
+            const expected: Array<IDealerOption> = response.dealers;
+            const actual = new OrderOptionsResponse(response).getDealerSites();
+
+            expect(actual).toEqual(expected);
         });
     });
 

--- a/src/orders/order-options-response.ts
+++ b/src/orders/order-options-response.ts
@@ -2,6 +2,7 @@ import { PaymentLookupResponse } from "../payments/payment-lookup-response";
 import {
     IAvailableInsuranceOption,
     IContactInformation,
+    IDealerOption,
     IDeliveryOption,
     IOrderOptionsResponse,
     IOrderOptionsResponseData,
@@ -17,6 +18,18 @@ export class OrderOptionsResponse implements IOrderOptionsResponse {
         }
 
         this.response = response;
+    }
+
+    public requiresDealerSelection(): boolean {
+        return this.response.dealers && this.response.dealers.length > 1;
+    }
+
+    public getDealerSites(): IDealerOption[] {
+        if (!this.response.dealers || !this.response.dealers.length) {
+            return [];
+        }
+
+        return this.response.dealers;
     }
 
     public getPaymentOptions(): IPaymentOption[] {

--- a/src/orders/types.ts
+++ b/src/orders/types.ts
@@ -23,9 +23,12 @@ export interface IOrderCreateResponseData {
 
 export interface IOrderOptionsRequest {
     id: string;
+    branchId?: string;
 }
 
 export interface IOrderOptionsResponse {
+    requiresDealerSelection(): boolean;
+    getDealerSites(): IDealerOption[];
     getPaymentOptions(): IPaymentOption[];
     getDeliveryOptions(): IDeliveryOption[];
     getInsuranceOption(): IAvailableInsuranceOption | undefined;
@@ -50,6 +53,7 @@ export interface IOrderPaymentRequest {
 }
 
 export interface IOrderOptionsResponseData {
+    dealers: IDealerOption[];
     conditions: string | undefined;
     returnConditions: string | undefined;
     conditionsPdfUri: string | null | undefined;
@@ -58,6 +62,19 @@ export interface IOrderOptionsResponseData {
     insurance: IAvailableInsuranceOption | undefined;
     payment: IPaymentOptionResponseData[];
     tradeIn: boolean;
+}
+
+export interface IDealerOption {
+    id: string;
+    name: string;
+    location: ILocation | undefined;
+}
+
+export interface ILocation {
+    address: string | undefined;
+    city: string | undefined;
+    latitude: number | undefined;
+    longitude: number | undefined;
 }
 
 export interface IOrderCustomer {

--- a/src/payments/payment-lookup-request-builder.spec.ts
+++ b/src/payments/payment-lookup-request-builder.spec.ts
@@ -66,6 +66,15 @@ describe("PaymentLookupRequestBuilder", () => {
         });
     });
 
+    describe(":forDealer()", () => {
+        it("returns the PaymentLookupRequestBuilder instance", () => {
+            const builder = new PaymentLookupRequestBuilder();
+            const instance = builder.forDealer("dealer-id");
+
+            expect(instance).toBe(builder);
+        });
+    });
+
     describe(":withDownPayment()", () => {
         it("returns the PaymentLookupRequestBuilder instance", () => {
             const builder = new PaymentLookupRequestBuilder();
@@ -98,6 +107,7 @@ describe("PaymentLookupRequestBuilder", () => {
             const expected = fixture("IPaymentLookupRequest");
             const actual = new PaymentLookupRequestBuilder()
                 .forVehicle(expected.id)
+                .forDealer(expected.branchId)
                 .withDownPayment(expected.downPayment)
                 .withDuration(expected.duration)
                 .build();

--- a/src/payments/payment-lookup-request-builder.ts
+++ b/src/payments/payment-lookup-request-builder.ts
@@ -26,6 +26,12 @@ export class PaymentLookupRequestBuilder {
         return this;
     }
 
+    public forDealer(id: string): PaymentLookupRequestBuilder {
+        this.properties.branchId = id;
+
+        return this;
+    }
+
     public withDuration(duration: number): PaymentLookupRequestBuilder {
         this.properties.duration = duration;
 

--- a/src/payments/types.ts
+++ b/src/payments/types.ts
@@ -1,4 +1,5 @@
 export interface IPaymentLookupRequest {
+    branchId: string;
     downPayment: number;
     duration: number;
     residual: number;

--- a/test/fixtures/index.js
+++ b/test/fixtures/index.js
@@ -160,8 +160,10 @@ factory.define("IOrderCreateResponse", [
 
 factory.define("IOrderOptionsRequest", [
     "id",
+    "branchId",
 ]);
 factory.define("IOrderOptionsResponse", [
+    "dealers".asListOfFixtures("IDealerOption", 2),
     "conditions",
     "returnConditions",
     "conditionsPdfUri",
@@ -170,6 +172,19 @@ factory.define("IOrderOptionsResponse", [
     "insurance".fromFixture("IOrderInsurance"),
     "payment".asListOfFixtures("IOrderPayment", 2),
     "tradeIn".asBoolean(),
+]);
+
+factory.define("IDealerOption", [
+    "id",
+    "name",
+    "location".fromFixture("ILocation"),
+]);
+
+factory.define("ILocation", [
+    "address",
+    "city",
+    "latitude".asNumber(),
+    "longitude".asNumber(),
 ]);
 
 factory.define("IPaymentCosts", [
@@ -193,6 +208,7 @@ factory.define("IPaymentRangeSpec", [
 ]);
 factory.define("IPaymentLookupRequest", [
     "id",
+    "branchId",
     "duration".asNumber(),
     "downPayment".asNumber(),
 ]);


### PR DESCRIPTION
When a vehicle is available on multiple branches, as a vehicle on a
central storage might be, it should be required for consumers to
display a dealer selection for whom the order belongs to - and to load
financial options and insurance options correctly.